### PR TITLE
fixing crash caused by straggler check failing during a run.

### DIFF
--- a/test/zfsbackup_tests.py
+++ b/test/zfsbackup_tests.py
@@ -96,6 +96,10 @@ class TestZFSBackup(unittest.TestCase):
         self.assertFalse(zfsbackup.has_stragglers(dataset))
         self.assertTrue(zfsbackup.has_stragglers(nope))
 
+    def testHasStragglersFail(self):
+        dataset = self.base_dataset+'/doesnotexist'
+        self.assertRaises(ZFSBackupError, zfsbackup.has_stragglers, dataset)
+
     def testRenameSnapshot(self):
         dataset = self.base_dataset+'/'+self.source_dataset
         to_rename = dataset+'@zfsbackup-rename'

--- a/zfsbackup.py
+++ b/zfsbackup.py
@@ -51,7 +51,14 @@ def main():
         dest = args.destination
         transport = args.transport
         dests = [{'dest': dest, 'transport': transport}]
-        if has_stragglers(name):
+        try:
+            stragglers = has_stragglers(name)
+        except ZFSBackupError:
+            logging.warn("Unable to get list of existing snapshots for "
+                         + "dataset: "+name+". IT WAS NOT BACKED UP!")
+            errors += 1
+
+        if stragglers:
             logging.warn("Dataset: "+name+" has left over temporary "
                          + "snapshots. IT WAS NOT BACKED UP! You need "
                          + "to resolve this manually. Make sure everything "
@@ -93,7 +100,14 @@ def main():
             # for each dataset check stragglers
             # if none, backup
             name = ds.get('dataset_name')
-            if has_stragglers(name):
+            try:
+                stragglers = has_stragglers(name)
+            except ZFSBackupError:
+                logging.warn("Unable to get list of existing snapshots for "
+                         + "dataset: "+name+". IT WAS NOT BACKED UP!")
+                errors += 1
+                continue
+            if stragglers:
                 logging.warn("Dataset: "+name+" has left over temporary "
                              + "snapshots. IT WAS NOT BACKED UP! You need "
                              + "to resolve this manually. Make sure "


### PR DESCRIPTION
This should fix the crash that occurs when a straggler check fails, ie the dataset doesn't exist, or something else causes the zfs list to return anything other than 0.