### PR TITLE
Fix a warning in newer versions of pyyaml

### DIFF
--- a/zfsbackup.py
+++ b/zfsbackup.py
@@ -163,7 +163,7 @@ def validate_config(conf_path):
                              + "running the program.")
     with open(conf_path) as conf_f:
         try:
-            conf = yaml.load(conf_f.read())
+            conf = yaml.safe_load(conf_f.read())
         except yaml.YAMLError as e:
             # parsing error
             logging.error("Invalid config file.")


### PR DESCRIPTION
Starting with pyyaml 5.1 the load function emits a warning on use. We're technically safe from
the issue that prompted this function being deprecated, but we're also not using any of the
features that doing anything other than safe_load gives us. So this just changes the call
to load() with safe_load().