### PR TITLE
Fixing descendent filesystem snapshot issues

### DIFF
--- a/zfsbackup.py
+++ b/zfsbackup.py
@@ -525,7 +525,7 @@ def get_snapshots(dataset):
     """
     # get list of snapshots
     try:
-        zfs = subprocess.run(['zfs', 'list', '-H', '-r', '-t', 'snapshot',
+        zfs = subprocess.run(['zfs', 'list', '-H', '-t', 'snapshot',
                               '-o', 'name', dataset], stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE, check=True, timeout=60,
                              encoding='utf-8')
@@ -576,7 +576,7 @@ def clean_dest_snaps(destinations, global_retain_snaps=None):
             num_snaps = global_retain_snaps
         else:
             num_snaps = dest.get('retain_snaps')
-        zfs_command = ['zfs', 'list', '-H', '-r', '-t', 'snapshot',
+        zfs_command = ['zfs', 'list', '-H', '-t', 'snapshot',
                        '-o', 'name', dataset]
         if transport.lower() == 'local':
             # local transport


### PR DESCRIPTION
For some reason when I originally wrote this I had the recursive
flag specified for the 'zfs list' invocations for enumerating
snapshots, this is not required, and breaks the assumptions this
code makes regarding snapshot deletion and count. Fixes #11.

This shouldn't break anything, but I've not run any tests yet.