### PR TITLE
Better snapshot list fix

### DIFF
--- a/zfsbackup.py
+++ b/zfsbackup.py
@@ -525,8 +525,9 @@ def get_snapshots(dataset):
     """
     # get list of snapshots
     try:
-        zfs = subprocess.run(['zfs', 'list', '-H', '-t', 'snapshot',
-                              '-o', 'name', dataset], stdout=subprocess.PIPE,
+        zfs_command = ['zfs', 'list', '-H', '-t', 'snapshot', '-d', '1',
+                       '-o', 'name', dataset]
+        zfs = subprocess.run(zfs_command, stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE, check=True, timeout=60,
                              encoding='utf-8')
         # remove empty lines and return a list with the contents of stdout
@@ -576,7 +577,7 @@ def clean_dest_snaps(destinations, global_retain_snaps=None):
             num_snaps = global_retain_snaps
         else:
             num_snaps = dest.get('retain_snaps')
-        zfs_command = ['zfs', 'list', '-H', '-t', 'snapshot',
+        zfs_command = ['zfs', 'list', '-H', '-t', 'snapshot', '-d', '1',
                        '-o', 'name', dataset]
         if transport.lower() == 'local':
             # local transport


### PR DESCRIPTION
This changes the fix for #15 a bit by returning to the recursive listing, but restricting it to a depth of 1, which should be just direct children of a dataset ie snapshots. This accounts for a behavior change between zfsonlinux 0.7.x and 0.8.x where on the 0.7.x series you had to recursively list if you wanted to get snapshots returned by list for a specific dataset. This is not required on 0.8.x hence my confusion in #15. 