### PR TITLE
Refactor and lz4 pipe addition

### DIFF
--- a/test/integration_test-setup.sh
+++ b/test/integration_test-setup.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/bash
-
-zfs create store/zfs_backup_test
-zfs create store/zfs_backup_test/source
-zfs create store/zfs_backup_test/source2
-zfs create store/zfs_backup_test/destination
-zfs create store/zfs_backup_test/destination2_local
-zfs create store/zfs_backup_test/destination2_ssh
+POOL=trash
+zfs create ${POOL}/zfs_backup_test
+zfs create ${POOL}/zfs_backup_test/source
+zfs create ${POOL}/zfs_backup_test/source2
+zfs create ${POOL}/zfs_backup_test/destination
+zfs create ${POOL}/zfs_backup_test/destination2_local
+zfs create ${POOL}/zfs_backup_test/destination2_ssh
 

--- a/test/integration_test-teardown.sh
+++ b/test/integration_test-teardown.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/bash
-
-zfs destroy -r store/zfs_backup_test
+POOL=trash
+zfs destroy -r ${POOL}/zfs_backup_test

--- a/test/integration_test.sh
+++ b/test/integration_test.sh
@@ -1,14 +1,15 @@
 #!/usr/bin/bash
+POOL=trash
 set -x
 set -e
 bash integration_test-setup.sh
-cp -r /etc/ /store/zfs_backup_test/source
-cp -r /etc/ /store/zfs_backup_test/source2
-python3	zfsbackup.py --config integration_test.yml
+cp -r /etc/ /${POOL}/zfs_backup_test/source
+cp -r /etc/ /${POOL}/zfs_backup_test/source2
+python3	../zfsbackup.py --config integration_test.yml
 sleep 62
-cp -r /usr/bin /store/zfs_backup_test/source
-cp -r /usr/bin /store/zfs_backup_test/source2
-python3 zfsbackup.py --config integration_test.yml
+cp -r /usr/bin /${POOL}/zfs_backup_test/source
+cp -r /usr/bin /${POOL}/zfs_backup_test/source2
+python3 ../zfsbackup.py --config integration_test.yml
 zfs list
 zfs list -t snap
 bash integration_test-teardown.sh

--- a/test/integration_test.yml
+++ b/test/integration_test.yml
@@ -4,17 +4,17 @@ lock_file: "./zfsbackup.lock"
 # dataset config
 datasets:
   -
-    dataset_name: "store/zfs_backup_test/source"
+    dataset_name: "trash/zfs_backup_test/source"
     destinations: 
     -
-      dest: "store/zfs_backup_test/destination"
+      dest: "trash/zfs_backup_test/destination"
       transport: "local"
   -
-    dataset_name: "store/zfs_backup_test/source2"
+    dataset_name: "trash/zfs_backup_test/source2"
     destinations:
       - 
-        dest: "store/zfs_backup_test/destination2_ssh"
+        dest: "trash/zfs_backup_test/destination2_ssh"
         transport: "ssh:root@localhost"
       - 
-        dest: "store/zfs_backup_test/destination2_local"
+        dest: "trash/zfs_backup_test/destination2_local"
         transport: "local"

--- a/test/test-setup.sh
+++ b/test/test-setup.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/bash
+POOL=trash
+zfs create ${POOL}/zfs_backup_test
+zfs create ${POOL}/zfs_backup_test/source
+zfs create ${POOL}/zfs_backup_test/other
+zfs create ${POOL}/zfs_backup_test/destination
+zfs create ${POOL}/zfs_backup_test/destination2
 
-zfs create store/zfs_backup_test
-zfs create store/zfs_backup_test/source
-zfs create store/zfs_backup_test/other
-zfs create store/zfs_backup_test/destination
-zfs create store/zfs_backup_test/destination2
-
-zfs snap store/zfs_backup_test/source@zfsbackup-expected
-zfs snap store/zfs_backup_test/source@zfsbackup-delete
-zfs snap store/zfs_backup_test/source@zfsbackup-last-test
-zfs snap store/zfs_backup_test/other@zfsbackup-20180507-142000
-zfs snap store/zfs_backup_test/source@zfsbackup-rename
+zfs snap ${POOL}/zfs_backup_test/source@zfsbackup-expected
+zfs snap ${POOL}/zfs_backup_test/source@zfsbackup-delete
+zfs snap ${POOL}/zfs_backup_test/source@zfsbackup-last-test
+zfs snap ${POOL}/zfs_backup_test/other@zfsbackup-20180507-142000
+zfs snap ${POOL}/zfs_backup_test/source@zfsbackup-rename

--- a/test/test-teardown.sh
+++ b/test/test-teardown.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/bash
-
-zfs destroy -r store/zfs_backup_test
+POOL=trash
+zfs destroy -r ${POOL}/zfs_backup_test

--- a/zfsbackup.py
+++ b/zfsbackup.py
@@ -765,7 +765,7 @@ def __cleanup_stdout(stdout):
     return list(filter(None, stdout.split('\n')))
 
 def get_transport_type(transport):
-    return transport if transport == "local" else transport.lower().split(':')[0]
+    return transport.lower() if transport.lower() == "local" else transport.lower().split(':')[0]
 
 def parse_ssh_transport(transport):
     """

--- a/zfsbackup.py
+++ b/zfsbackup.py
@@ -198,7 +198,7 @@ def backup_dataset(dataset, destinations, inc_snap):
                 # if we're doing ssh and the connection fails abort to avoid nuisance snapshot cleanup.
                 username, hostname, port = parse_ssh_transport(transport)
                 try:
-                    __run_ssh_command(username, hostname, port, "zfs --version")
+                    __run_ssh_command(username, hostname, port, ["zfs", "--version"])
                 except CalledProcessError as e:
                     raise ZFSBackupError("Error: Test connection to "+transport+" failed. Aborting.")
                 except TimeoutExpired as e:
@@ -762,7 +762,10 @@ def __cleanup_stdout(stdout):
        param stdout: string output of subprocess stdout
        returns: list of lines from stdout
     """
-    return list(filter(None, stdout.split('\n')))
+    if stdout is None:
+        return ["No output"]
+    else:
+        return list(filter(None, stdout.split('\n')))
 
 def get_transport_type(transport):
     return transport.lower() if transport.lower() == "local" else transport.lower().split(':')[0]

--- a/zfsbackup.py
+++ b/zfsbackup.py
@@ -460,35 +460,38 @@ def send_snapshot(snapshot, destination, transport='local',
                              + transport.lower()+"> to "+destination)
                              
     elif get_transport_type(transport) == "ssh":
+        zsend_command = ["zfs", "send", snapshot]
         username, hostname, port = parse_ssh_transport(transport)
         with run('zfs send', zsend_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE) as zfs_send:
             # TODO: have a configurable for ssh-key instead of just assuming
-            ssh_remote_command = "zfs recv "+recv_flags+" "+destination
+            ssh_remote_command = "lz4 -d | zfs recv "+recv_flags+" "+destination
             ssh_command = ['ssh', '-o', 'PreferredAuthentications=publickey',
                            '-o', 'PubkeyAuthentication=yes',
                            '-o', 'StrictHostKeyChecking=yes', '-p', port, '-l',
                            username, hostname, ssh_remote_command]
-            with run('ssh recv', ssh_command, stdin=zfs_send.stdout, stderr=subprocess.PIPE) as ssh_recv:
-                try:
-                    ssh_recv.wait()
-                    if ssh_recv.returncode != 0:
-                        zfs_send.kill()
-                        zfs_send.wait()
-                        raise ZFSBackupError("ssh recv of "+snapshot+" to "
-                                             + destination+" failed.")
+            lz4_command = ["lz4"]
+            with run("lz4 pipe", lz4_command, stdin=zfs_send.stdout, stderr=subprocess.PIPE) as lz4:
+                with run('ssh recv', ssh_command, stdin=lz4.stdout, stderr=subprocess.PIPE) as ssh_recv:
+                    try:
+                        ssh_recv.wait()
+                        if ssh_recv.returncode != 0:
+                            zfs_send.kill()
+                            zfs_send.wait()
+                            raise ZFSBackupError("ssh recv of "+snapshot+" to "
+                                                + destination+" failed.")
 
-                    zfs_send.wait()
-                    if zfs_send.returncode != 0:
-                        raise ZFSBackupError("zfs send of "+snapshot+" to"
-                                             + destination+" failed.")
-                except Exception as e:
-                    raise ZFSBackupError("Caught an exception while sending "+str(e))
-                if (zfs_send.returncode != 0) or (ssh_recv.returncode != 0):
-                    # we failed somewhere
-                    raise ZFSBackupError("Send of "+snapshot+" to "
-                                         + destination+" failed.")
-                logging.info("Finished send of "+snapshot+"via <"
-                             + transport.lower()+"> to "+destination)
+                        zfs_send.wait()
+                        if zfs_send.returncode != 0:
+                            raise ZFSBackupError("zfs send of "+snapshot+" to"
+                                                + destination+" failed.")
+                    except Exception as e:
+                        raise ZFSBackupError("Caught an exception while sending "+str(e))
+                    if (zfs_send.returncode != 0) or (ssh_recv.returncode != 0):
+                        # we failed somewhere
+                        raise ZFSBackupError("Send of "+snapshot+" to "
+                                            + destination+" failed.")
+                    logging.info("Finished send of "+snapshot+"via <"
+                                + transport.lower()+"> to "+destination)
     else:
         # some transport we don't support
         # shouldn't happen with config parsing

--- a/zfsbackup.py
+++ b/zfsbackup.py
@@ -192,15 +192,42 @@ def backup_dataset(dataset, destinations, inc_snap):
        param inc_snap: the incremental source snapshot
        raises: ZFSBackupError"""
     try:
+        for d in destinations:
+            transport = d.get("transport")
+            if get_transport_type(transport) == "ssh":
+                # if we're doing ssh and the connection fails abort to avoid nuisance snapshot cleanup.
+                username, hostname, port = parse_ssh_transport(transport)
+                try:
+                    __run_ssh_command(username, hostname, port, "zfs --version")
+                except CalledProcessError as e:
+                    raise ZFSBackupError("Error: Test connection to "+transport+" failed. Aborting.")
+                except TimeoutExpired as e:
+                    raise ZFSBackupError("Error: Test connection to "+transport+" timed out. Aborting.")
         new_snap = create_timestamp_snap(dataset)
         if has_backuplast(dataset, inc_snap):
+            errors = 0
             # do incremental
             for d in destinations:
-                send_incremental(dataset+inc_snap, dataset+new_snap,
-                                 d.get('dest'), transport=d.get('transport'))
-                logging.info("Incremental send of "+dataset+new_snap+" to "
-                             + d.get('dest')+" via "+d.get('transport')
+                current_errors = False
+                destination = d.get("dest")
+                transport = d.get("transport")
+                try:
+                    send_incremental(dataset+inc_snap, dataset+new_snap,
+                                     destination, transport=transport)
+                    logging.info("Incremental send of "+dataset+new_snap+" to "
+                             + destination+" via "+transport
                              + " finished.")
+                except ZFSBackupError as e:
+                    errors += 1
+                    current_errors = True
+                if not current_errors and verify_backup(new_snap, destination, transport):
+                    # good backup
+                    logging.info("Verifcation of "+destination+new_snap+" via "+transport+" succeeded")
+                else:
+                    # verify failed for whatever reason
+                    errors +=1
+            if errors > 0:
+                raise ZFSBackupError("Errors were encountered while backing up "+dataset+new_snap+". Please check the logs.")
             # delete old incremental marker
             try:
                 delete_snapshot(dataset+inc_snap)
@@ -209,35 +236,29 @@ def backup_dataset(dataset, destinations, inc_snap):
                 logging.error("Unable to delete "+dataset+inc_snap
                               + " YOU NEED TO DELETE THAT AND THEN RENAME "
                               + dataset+new_snap+" TO "+dataset+inc_snap)
-                raise e
         else:
             # do full send
+            errors = 0
             for d in destinations:
-                send_full(dataset+new_snap, d.get('dest'),
-                          transport=d.get('transport'))
-                logging.info("Full send of "+dataset+new_snap+" to "
-                             + d.get('dest')
-                             + " via "+d.get('transport')+" finished.")
-        errors = 0
-        for d in destinations:
-            if verify_backup(new_snap, d.get('dest'), d.get('transport')):
-                # good backup
-                logging.info("Verification of "+d.get('dest')+new_snap+" via "
-                             + d.get('transport')+" finished.")
-            else:
-                # bad backup note
-                logging.error("Verification of "+d.get('dest')+new_snap+" via"
-                              + d.get('transport')+" FAILED!")
-                errors += 1
+                current_errors = False
+                destination = d.get("dest")
+                transport = d.get("transport")
                 try:
-                    delete_snapshot(dataset+new_snap)
-                except Exception as e:
-                    logging.error("Unable to clean up snapshot "
-                                  + dataset+new_snap
-                                  + " after failed verification.")
-        if errors > 0:
-            raise ZFSBackupError("Verification of "+d.get('dest')+new_snap
-                                 + " FAILED!")
+                    send_full(dataset+new_snap, destination,
+                            transport=transport)
+                    logging.info("Full send of "+dataset+new_snap+" to "
+                             + destination
+                             + " via "+transport+" finished.")
+                except ZFSBackupError as e:
+                    errors += 1
+                if not current_errors and verify_backup(new_snap, destination, transport):
+                    # good backup
+                    logging.info("Verifcation of "+destination+new_snap+" via "+transport+" succeeded")
+                else:
+                    # verify failed
+                    errors += 1
+            if errors > 0:
+                raise ZFSBackupError("Errors were encountered while backing up "+dataset+new_snap+". Please check the logs.")
         # rename dataset+new_snap to dataset+inc_snap
         try:
             rename_snapshot(dataset+new_snap, dataset+inc_snap)
@@ -261,14 +282,14 @@ def verify_backup(snapshot, destination, transport):
        returns: True if the snapshot is present at destination, else False
        """
     try:
-        if transport == 'local':
+        if get_transport_type(transport) == 'local':
             zfs_command = ['zfs', 'list', '-H', '-t', 'snapshot',
                            '-o', 'name', destination+snapshot]
             zfs = subprocess.run(zfs_command, check=True, timeout=60,
                                  encoding='utf-8', stderr=subprocess.DEVNULL,
                                  stdout=subprocess.DEVNULL)
             return True
-        elif transport.lower().split(':')[0] == 'ssh':
+        elif get_transport_type(transport) == 'ssh':
             # TODO: make the ssh communication it's own function probably
             username, hostname, port = parse_ssh_transport(transport)
             zfs = "zfs list -H -t snapshot -o name "+destination+snapshot
@@ -419,7 +440,7 @@ def send_snapshot(snapshot, destination, transport='local',
     else:
         zsend_command = ['zfs', 'send', send_flags, snapshot]
     zrecv_command = ['zfs', 'recv', recv_flags, destination]
-    if transport.lower() == 'local':
+    if get_transport_type(transport) == 'local':
         with run('zfs send', zsend_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE) as zfs_send:
             with run('zfs recv', zrecv_command, stdin=zfs_send.stdout, stderr=subprocess.PIPE) as zfs_recv:
                 try:
@@ -438,14 +459,10 @@ def send_snapshot(snapshot, destination, transport='local',
                 logging.info("Finished send of "+snapshot+" via <"
                              + transport.lower()+"> to "+destination)
                              
-    elif transport.lower().split(':')[0] == 'ssh':
-        port = '22'
-        if len(transport.split(':')) > 2:
-            # assume that the 3rd element is a port number
-            port = transport.split(':')[2]
+    elif get_transport_type(transport) == "ssh":
+        username, hostname, port = parse_ssh_transport(transport)
         with run('zfs send', zsend_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE) as zfs_send:
             # TODO: have a configurable for ssh-key instead of just assuming
-            username, hostname = transport.split(':')[1].split('@')
             ssh_remote_command = "zfs recv "+recv_flags+" "+destination
             ssh_command = ['ssh', '-o', 'PreferredAuthentications=publickey',
                            '-o', 'PubkeyAuthentication=yes',
@@ -604,7 +621,7 @@ def clean_dest_snaps(destinations, global_retain_snaps=None):
             num_snaps = dest.get('retain_snaps')
         zfs_command = ['zfs', 'list', '-H', '-t', 'snapshot', '-d', '1',
                        '-o', 'name', dataset]
-        if transport.lower() == 'local':
+        if get_transport_type(transport) == 'local':
             # local transport
             try:
                 snaps = __snap_delete_format(__run_command(zfs_command), num_snaps)
@@ -625,7 +642,7 @@ def clean_dest_snaps(destinations, global_retain_snaps=None):
                 logging.warning("Encountered errors while deleting old snapshots" 
                              + "from destination: "+dataset+" via "
                              + transport)
-        elif transport.lower().split(':')[0] == 'ssh':
+        elif get_transport_type(transport) == 'ssh':
             # ssh transport
             user, host, port  = parse_ssh_transport(transport)
             try:
@@ -747,6 +764,8 @@ def __cleanup_stdout(stdout):
     """
     return list(filter(None, stdout.split('\n')))
 
+def get_transport_type(transport):
+    return transport if transport == "local" else transport.lower().split(':')[0]
 
 def parse_ssh_transport(transport):
     """


### PR DESCRIPTION
-c and -e on send are very nice as long as you're keeping the same compression on the receiving side. Given zstd is now available and we're doing a hardware refresh I decided to change the backups to zstd but I want to retain the transfer benefits of lz4 compression.

This adds an lz4 step in the pipeline to hopefully still save on transfers.